### PR TITLE
Install build dependencies for Python 3.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ jobs:
       uses: fedora-python/tox-github-action@main
       with:
         tox_env: ${{ matrix.tox_env }}
+        dnf_install: gcc libxml2-devel libxslt-devel
     strategy:
       matrix:
         tox_env:


### PR DESCRIPTION
Upstream drop support for Python 2.7 and 3.6 in one of the latest releases so we need to install build deps to build lxml wheel from sources.