### PR TITLE
Improve memory efficiency by discarding references to objects immediately

### DIFF
--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -5,6 +5,7 @@ import unittest
 
 import lxml.html
 from lxml_html_clean import Cleaner, clean_html
+from .utils import peak_memory_usage
 
 
 class CleanerTest(unittest.TestCase):
@@ -333,3 +334,15 @@ class CleanerTest(unittest.TestCase):
         expected = """<a href="">Link</a>"""
         cleaner = Cleaner()
         self.assertEqual(expected, cleaner.clean_html(html))
+
+    def test_memory_usage_many_elements_with_long_tails(self):
+        comment = "<!-- foo bar baz -->\n"
+        empty_line = "\t" * 10 + "\n"
+        element = comment + empty_line * 10
+        content = element * 5_000
+        html = f"<html>{content}</html>"
+
+        cleaner = Cleaner()
+        mem = peak_memory_usage(cleaner.clean_html, html)
+
+        self.assertTrue(mem < 10, f"Used {mem} MiB memory, expected at most 10 MiB")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,18 @@
+import unittest
+
+
+def peak_memory_usage(func, *args, **kwargs):
+    """
+    Monitor the memory usage of a function and return the peak memory used, in MiB.
+    """
+    try:
+        from memory_profiler import memory_usage  # type: ignore
+    except ImportError:
+        raise unittest.SkipTest("memory-profiler is not available")
+
+    try:
+        mem_usage = memory_usage((func, args, kwargs), interval=0.1, timeout=None)
+    except MemoryError:
+        return float("inf")
+    peak_memory = max(mem_usage) - min(mem_usage)
+    return peak_memory

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,11 @@ skipsdist = True
 
 [testenv]
 commands =
-  python -m unittest tests.test_clean
+  python -m unittest -v tests.test_clean
   python -m doctest tests/test_clean_embed.txt tests/test_clean.txt tests/test_autolink.txt
-deps = lxml
+deps =
+  lxml
+  memory_profiler
 
 [testenv:mypy]
 commands =


### PR DESCRIPTION
When "killing" or "removing" elements from a tree, it's important not to keep references to them in the lists where they're collected.

For more info see: https://bugs.launchpad.net/lxml/+bug/1889653