### PR TITLE
Build atrifacts now contain all test files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,14 @@ lxml_html_clean changelog
 Unreleased
 ==========
 
+0.2.2 (2024-08-30)
+==================
+
+Bugs fixed
+----------
+
+* sdist now includes all test files and changelog.
+
 0.2.1 (2024-08-29)
 ==================
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+recursive-include tests *.txt *.py
+include tox.ini
+include CHANGES.rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = lxml_html_clean
-version = 0.2.1
+version = 0.2.2
 description = HTML cleaner from lxml project
 long_description = file:README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Fixes: https://github.com/fedora-python/lxml_html_clean/issues/15