### PR TITLE
Scan for JS code also in CSS comments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Bugs fixed
   within CSS comments. In certain contexts, such as within ``<svg>`` or ``<math>`` tags,
   ``<style>`` tags may lose their intended function, allowing comments
   like ``/* foo */`` to potentially be executed by the browser.
+  If a suspicious content is detected, only the comment is removed.
 
 0.3.1 (2024-10-09)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,17 @@ lxml_html_clean changelog
 Unreleased
 ==========
 
+0.4.0 (2024-11-12)
+==================
+
+Bugs fixed
+----------
+
+* The ``Cleaner()`` now scans for hidden JavaScript code embedded
+  within CSS comments. In certain contexts, such as within ``<svg>`` or ``<math>`` tags,
+  ``<style>`` tags may lose their intended function, allowing comments
+  like ``/* foo */`` to potentially be executed by the browser.
+
 0.3.1 (2024-10-09)
 ==================
 

--- a/lxml_html_clean/clean.py
+++ b/lxml_html_clean/clean.py
@@ -581,22 +581,27 @@ class Cleaner:
         that and remove only the Javascript from the style; this catches
         more sneaky attempts.
         """
-        style = self._substitute_comments('', style)
-        style = style.replace('\\', '')
         style = _substitute_whitespace('', style)
         style = style.lower()
-        if _has_javascript_scheme(style):
-            return True
-        if 'expression(' in style:
-            return True
-        if '@import' in style:
-            return True
-        if '</noscript' in style:
-            # e.g. '<noscript><style><a title="</noscript><img src=x onerror=alert(1)>">'
-            return True
-        if _looks_like_tag_content(style):
-            # e.g. '<math><style><img src=x onerror=alert(1)></style></math>'
-            return True
+
+        for with_comments in True, False:
+            if not with_comments:
+                style = self._substitute_comments('', style)
+
+            style = style.replace('\\', '')
+
+            if _has_javascript_scheme(style):
+                return True
+            if 'expression(' in style:
+                return True
+            if '@import' in style:
+                return True
+            if '</noscript' in style:
+                # e.g. '<noscript><style><a title="</noscript><img src=x onerror=alert(1)>">'
+                return True
+            if _looks_like_tag_content(style):
+                # e.g. '<math><style><img src=x onerror=alert(1)></style></math>'
+                return True
         return False
 
     def clean_html(self, html):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = lxml_html_clean
-version = 0.3.1
+version = 0.4.0
 description = HTML cleaner from lxml project
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -127,6 +127,23 @@ class CleanerTest(unittest.TestCase):
             b'<math><style>/* deleted */</style></math>',
             lxml.html.tostring(clean_html(s)))
 
+    def test_sneaky_js_in_style_comment_math_svg(self):
+        for tag in "svg", "math":
+            html = f'<{tag}><style>/*<img src onerror=alert(origin)>*/'
+            s = lxml.html.fragment_fromstring(html)
+
+            self.assertEqual(
+                f'<{tag}><style>/* deleted */</style></{tag}>'.encode(),
+                lxml.html.tostring(clean_html(s)))
+
+    def test_sneaky_js_in_style_comment_noscript(self):
+        html = '<noscript><style>/*</noscript><img src onerror=alert(origin)>*/'
+        s = lxml.html.fragment_fromstring(html)
+
+        self.assertEqual(
+            b'<noscript><style>/* deleted */</style></noscript>',
+            lxml.html.tostring(clean_html(s)))
+
     def test_sneaky_import_in_style(self):
         # Prevent "@@importimport" -> "@import" replacement etc.
         style_codes = [

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -129,19 +129,21 @@ class CleanerTest(unittest.TestCase):
 
     def test_sneaky_js_in_style_comment_math_svg(self):
         for tag in "svg", "math":
-            html = f'<{tag}><style>/*<img src onerror=alert(origin)>*/'
+            html = f'<{tag}><style>p {{color: red;}}/*<img src onerror=alert(origin)>*/h2 {{color: blue;}}</style></{tag}>'
             s = lxml.html.fragment_fromstring(html)
 
+            expected = f'<{tag}><style>p {{color: red;}}/* deleted */h2 {{color: blue;}}</style></{tag}>'.encode()
+
             self.assertEqual(
-                f'<{tag}><style>/* deleted */</style></{tag}>'.encode(),
+                expected,
                 lxml.html.tostring(clean_html(s)))
 
     def test_sneaky_js_in_style_comment_noscript(self):
-        html = '<noscript><style>/*</noscript><img src onerror=alert(origin)>*/'
+        html = '<noscript><style>p {{color: red;}}/*</noscript><img src onerror=alert(origin)>*/h2 {{color: blue;}}</style></noscript>'
         s = lxml.html.fragment_fromstring(html)
 
         self.assertEqual(
-            b'<noscript><style>/* deleted */</style></noscript>',
+            b'<noscript><style>p {{color: red;}}/* deleted */h2 {{color: blue;}}</style></noscript>',
             lxml.html.tostring(clean_html(s)))
 
     def test_sneaky_import_in_style(self):


### PR DESCRIPTION
The `Cleaner()` now scans for hidden JavaScript code embedded
within CSS comments. In certain contexts, such as within `<svg>`
or `<math>` tags, `<style>` tags may lose their intended function,
allowing comments like `/* foo */` to potentially be executed by
the browser.