### PR TITLE
<iframe> tag must have closing tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,6 @@ jobs:
     strategy:
       matrix:
         tox_env:
-          - py36
           - py38
           - py39
           - py310

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,6 @@ jobs:
       uses: fedora-python/tox-github-action@main
       with:
         tox_env: ${{ matrix.tox_env }}
-        dnf_install: gcc libxml2-devel libxslt-devel
     strategy:
       matrix:
         tox_env:

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -321,7 +321,7 @@ class CleanerTest(unittest.TestCase):
         # creates a host_whitelist of the empty string; a malformed triple-slash
         # URL has an "empty host" according to urlsplit, and `"" in ""` passes.
         # So, don't allow user to accidentally pass a string for host_whitelist.
-        html = '<div><iframe src="https:///evil.com/page"></div>'
+        html = '<div><iframe src="https:///evil.com/page"></iframe></div>'
         with self.assertRaises(TypeError) as exc:
             # If this were the intended `("example.com",)` the expected
             # output would be '<div></div>'
@@ -331,20 +331,20 @@ class CleanerTest(unittest.TestCase):
 
     def test_host_whitelist_valid(self):
         # Frame with valid hostname in src is allowed.
-        html = '<div><iframe src="https://example.com/page"></div>'
+        html = '<div><iframe src="https://example.com/page"></iframe></div>'
         expected = '<div><iframe src="https://example.com/page"></iframe></div>'
         cleaner = Cleaner(frames=False, host_whitelist=["example.com"])
         self.assertEqual(expected, cleaner.clean_html(html))
 
     def test_host_whitelist_invalid(self):
-        html = '<div><iframe src="https://evil.com/page"></div>'
+        html = '<div><iframe src="https://evil.com/page"></iframe></div>'
         expected = '<div></div>'
         cleaner = Cleaner(frames=False, host_whitelist=["example.com"])
         self.assertEqual(expected, cleaner.clean_html(html))
 
     def test_host_whitelist_sneaky_userinfo(self):
         # Regression test: Don't be fooled by hostname and colon in userinfo.
-        html = '<div><iframe src="https://example.com:@evil.com/page"></div>'
+        html = '<div><iframe src="https://example.com:@evil.com/page"></iframe></div>'
         expected = '<div></div>'
         cleaner = Cleaner(frames=False, host_whitelist=["example.com"])
         self.assertEqual(expected, cleaner.clean_html(html))

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -321,7 +321,7 @@ class CleanerTest(unittest.TestCase):
         # creates a host_whitelist of the empty string; a malformed triple-slash
         # URL has an "empty host" according to urlsplit, and `"" in ""` passes.
         # So, don't allow user to accidentally pass a string for host_whitelist.
-        html = '<div><iframe src="https:///evil.com/page"></iframe></div>'
+        html = '<div><iframe src="https:///evil.com/page"></div>'
         with self.assertRaises(TypeError) as exc:
             # If this were the intended `("example.com",)` the expected
             # output would be '<div></div>'

--- a/tests/test_clean.txt
+++ b/tests/test_clean.txt
@@ -84,7 +84,7 @@
   <body onload="evil_function()">
     <!-- I am interpreted for EVIL! -->
     <a href="javascript:evil_function()">a link</a>
-    <a href="javascrip%20t%20:evil_function()">a control char link</a>
+    <a href="j%01a%02v%03a%04s%05c%06r%07i%0Ep%20t%20:evil_function()">a control char link</a>
     <a href="data:text/html;base64,PHNjcmlwdD5hbGVydCgidGVzdCIpOzwvc2NyaXB0Pg==">data</a>
     <a href="#" onclick="evil_function()">another link</a>
     <p onclick="evil_function()">a paragraph</p>

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py38,py39,py310,py311,py312,py313,mypy
+envlist = py38,py39,py310,py311,py312,py313,mypy
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
If closing tag is missing, some undefined behaviors will provides test failure.

This PR fixes #24 .